### PR TITLE
Enhance Redoer exception handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,6 +208,11 @@ docker compose run --env AWS_PROFILE=localstack --env S3_BUCKET_NAME=sqs-senzing
 
 `LOG_LEVEL` is optional; defaults to `INFO`.
 
+`MAX_REDO_ATTEMPTS` (defaults to 20): It's possible that Senzing's
+`process_redo_record` might raise an `SzRetryableError`; this variable sets the
+max attempts the redoer will make to redo a particular record (if/when this
+particular error keeps getting raised) before moving on to the next record.
+
 You can view information about files in the LocalStack S3 bucket by visiting
 this URL:
 

--- a/README.md
+++ b/README.md
@@ -55,9 +55,9 @@ and run the consumer service on our local machine. This setup includes:
 
 Access the `tools` container to interact with the services:
 
-    ```bash
-    docker compose run tools /bin/bash
-    ```
+```bash
+docker compose run tools /bin/bash
+```
 
 The `tools` container should be configured with the necessary environment
 variables to interact with the SQS and S3 services in LocalStack, as well as the
@@ -178,11 +178,11 @@ Spinning up the consumer middleware (intended to be a continually-running
 process; in a production scenario, multiple instances could be running 
 simultaneously as needed):
 
-   ```bash
-   docker compose run --env AWS_PROFILE=localstack --env \
-   Q_URL="http://sqs.us-east-1.localhost.localstack.cloud:4566/000000000000/sqs-senzing-local-ingest" \
-   --env LOG_LEVEL=DEBUG consumer
-   ```
+```bash
+docker compose run --env AWS_PROFILE=localstack --env \
+Q_URL="http://sqs.us-east-1.localhost.localstack.cloud:4566/000000000000/sqs-senzing-local-ingest" \
+--env LOG_LEVEL=DEBUG consumer
+```
 
 `LOG_LEVEL` is optional; defaults to `INFO`.
 
@@ -190,9 +190,9 @@ simultaneously as needed):
 
 Similar to the consumer, the redoer is also a continually-running process.
 
-    ```bash
-    docker compose run --env AWS_PROFILE=localstack --env LOG_LEVEL=DEBUG redoer
-    ```
+```bash
+docker compose run --env AWS_PROFILE=localstack --env LOG_LEVEL=DEBUG redoer
+```
 
 `LOG_LEVEL` is optional; defaults to `INFO`.
 
@@ -201,10 +201,10 @@ Similar to the consumer, the redoer is also a continually-running process.
 Spinning up the exporter middleware (this is intended to be an ephemeral
 container):
 
-  ```bash
-  docker compose run --env AWS_PROFILE=localstack --env S3_BUCKET_NAME=sqs-senzing-local-export \
-  --env LOG_LEVEL=INFO exporter
-  ```
+```bash
+docker compose run --env AWS_PROFILE=localstack --env S3_BUCKET_NAME=sqs-senzing-local-export \
+--env LOG_LEVEL=INFO exporter
+```
 
 `LOG_LEVEL` is optional; defaults to `INFO`.
 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -84,7 +84,6 @@ services:
       - ~/.aws:/home/senzing/.aws
 
   consumer:
-    profiles: [middleware]
     build:
       context: .
       dockerfile: Dockerfile.consumer
@@ -106,12 +105,12 @@ services:
           }
         }
       Q_URL: http://sqs.us-east-1.localhost.localstack.cloud:4566/000000000000/sqs-senzing-local-ingest
+      AWS_PROFILE: localstack
     volumes:
       # Note: `.aws` mount might not be needed later.
       - ~/.aws:/home/senzing/.aws
 
   redoer:
-    profiles: [middleware]
     build:
       context: .
       dockerfile: Dockerfile.redoer
@@ -136,7 +135,6 @@ services:
       - ~/.aws:/home/senzing/.aws
 
   exporter:
-    profiles: [middleware]
     build:
       context: .
       dockerfile: Dockerfile.exporter

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -84,6 +84,7 @@ services:
       - ~/.aws:/home/senzing/.aws
 
   consumer:
+    profiles: [middleware]
     build:
       context: .
       dockerfile: Dockerfile.consumer
@@ -110,6 +111,7 @@ services:
       - ~/.aws:/home/senzing/.aws
 
   redoer:
+    profiles: [middleware]
     build:
       context: .
       dockerfile: Dockerfile.redoer
@@ -134,6 +136,7 @@ services:
       - ~/.aws:/home/senzing/.aws
 
   exporter:
+    profiles: [middleware]
     build:
       context: .
       dockerfile: Dockerfile.exporter

--- a/middleware/consumer.py
+++ b/middleware/consumer.py
@@ -72,7 +72,8 @@ def get_msgs(sqs, q_url):
             if 'Messages' in resp and len(resp['Messages']) == 1:
                 yield resp['Messages'][0]
         except Exception as e:
-            log.error(AWS_TAG + str(e))
+            log.error(f'{AWS_TAG} {type(e).__module__}.{type(e).__qualname__} :: {e}')
+            sys.exit(1)
    
 def del_msg(sqs, q_url, receipt_handle):
     try:

--- a/middleware/redoer.py
+++ b/middleware/redoer.py
@@ -64,7 +64,7 @@ def go():
                 try:
                     sz_eng.process_redo_record(rcd)
                     have_rcd = 0
-                    log.debug(SZ_TAG + 'Successfully redid one record.')
+                    log.debug(SZ_TAG + 'Successfully redid one record via process_redo_record().')
                     continue
                 except sz.SzRetryableError as sz_ret_err:
                     # We'll try to process this record again.

--- a/middleware/redoer.py
+++ b/middleware/redoer.py
@@ -22,6 +22,8 @@ SZ_CONFIG = json.loads(os.environ['SENZING_ENGINE_CONFIGURATION_JSON'])
 # How long to wait before attempting next Senzing op.
 WAIT_SECONDS = int(os.environ.get('WAIT_SECONDS', 10))
 
+MAX_REDO_ATTEMPTS = int(os.environ.get('MAX_REDO_ATTEMPTS', 20))
+
 #-------------------------------------------------------------------------------
 
 def go():
@@ -54,19 +56,25 @@ def go():
     tally = None
     have_rcd = 0
     rcd = None
+    attempts_left = MAX_REDO_ATTEMPTS
     while 1:
         try:
 
             if have_rcd:
                 try:
                     sz_eng.process_redo_record(rcd)
-                    rcd = None      # <-- TODO this op might not be necessary
                     have_rcd = 0
                     log.debug(SZ_TAG + 'Successfully redid one record.')
                     continue
                 except sz.SzRetryableError as sz_ret_err:
                     # We'll try to process this record again.
                     log.error(SZ_TAG + str(sz_ret_err))
+                    attempts_left -= 1
+                    log.debug(SZ_TAG + f'Remaining attempts for this record: {attempts_left}')
+                    if not attempts_left:
+                        have_rcd = 0
+                        log.error(SZ_TAG + f'Max redo attempts ({MAX_REDO_ATTEMPTS}) reached'
+                                  + ' for this record; dropping on the floor and moving on.')
                     time.sleep(WAIT_SECONDS)
                     continue
                 except sz.SzError as sz_err:
@@ -91,6 +99,7 @@ def go():
                         rcd = sz_eng.get_redo_record()
                         if rcd:
                             have_rcd = 1
+                            attempts_left = MAX_REDO_ATTEMPTS
                             # At this point, rcd var holds a record, and have_rcd flag
                             # raised. Will process in the next loop.
                             log.debug(SZ_TAG + 'Retrieved 1 record via get_redo_record()')
@@ -98,6 +107,7 @@ def go():
                             log.debug(SZ_TAG + 'Redo count was greater than 0, but got '
                                       + 'nothing from get_redo_record')
                     except sz.SzRetryableError as sz_ret_err:
+                        # No additional action needed; we'll just try getting again.
                         log.error(SZ_TAG + str(sz_ret_err))
                     except sz.SzError as sz_err:
                         log.error(SZ_TAG + str(sz_err))


### PR DESCRIPTION
- Redoer: add MAX_REDO_ATTEMPTS logic; right now, after reaching the maximum attempts, it will 'drop it on the floor' and move on to the next item in Senzing's redo queue.
- Consumer: will fail fast if SQS receiveMessage errors (incl. specifically NoCredentialsError)